### PR TITLE
Docker build from the sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ jobs:
         - secure: 5ae8Me0tn6lH476L9RtZJpZT9ZDyrGtWK1+VLZ7uUOd7Ip98YoU6fCndrw0zdRzYbu+8NFsZ+Iu0st6U2mgMuwWxTSEnlGIBEzPnqbG73jHpOtOChBFmsXqI1HfXq0GozSTYq+uCNpmXm34aTgZmMN0E0O4khnKpOUk/bgXDGrSbsV4rzCrTt/Q1rSHgg6kHRrRxNnYdANaLOlP6U9FcbyyEE7863AXKLZsOnendoewRO/eupsTMj6BOhA+/ANEkn8Lz0/3OrUiLUB32tvr8c5sPuZZkDktVprLvgR8vHpoCZYHnhJMc4Jjo4fqx5bz1LBYXaGvM2p+sO19ij1GI034OfgIG1Xnv8hoyBO/X7fVTy8ss2nKIQou/RXK1UNGVsBrLN+Sb9ErTLYVvupSSu+Cti/t1DGp9ksbbybRfvgLvGcg31ArsqJ/GOUryOObict7abJRP2LuR+y3OJW4iFPB3iFk8vw+4Tf5lCQPpNp1kIDL3hxG5Wn74kS41mxPVu2IeH9iN5MEUsjH1Q7g1mgNFEQERFron+X/vSEXA8ATXEDK6+EQahEYwuAO0zoIiGDaK3jta1r9Js45nuTXFGyZBd/u5fnprx77e22iKbyzU46Ru2BxoLa6KuaLOSu/TyCV1zaUaO4ged9Zuen7Zq5x8id/sXy8wDT/d+sA3Q2A=
         - secure: 3wSlarJAyfE2C4qeKO+lWInZsvAfYTWCB/s7U4/7jnOS2ZjMTZZ/I2GGSk2lOvW73kMEuez4Bz0VwADJg3RkdgC4a0eeUfWJt0IEkquzGRGyYVeB315R7OuO++rJaCsEwYZPloN3SdDgcuXxe3GsOeLCFKYABLPN1E4+P5j+5Ke4OKIW43EcNiAS2sTWYZikHyFGDi94DTX4z+gt0YmqloB3QOy3NzeHXIvoZgTIe3DqQx1kRhQvQfPvieBEaXvi69Pz31VwoaR9hnNo4eyGGOxvZk160fn9tCAw9byrcB7gZV/KTZ/OfcmFPbrsz/nUAH9WcKzLDYVo4D8H0KrKBKWN6KeHu21lVicTvBWJx3y5vBg0xVMYUvgv5KyQz+uoJzBj+u3uelFi7joIXhS+rYVaSnUuZ4VQoy7mDmwsjim1h6bCor6plQUqYdNpjk9cAiONU/Q0DymokYwofK5Ngq3EvHgXBUqY5ldRbxlr5pT0Vjhh2WIs3Rw9P4v8VnbqpfT+pYJRfyQKfHLvwDv/ag08tKMjhzqznfNxQnceq7Jzp2s0kcl37YP2DaUBSojECxXkQDgFAWaGoQZSuhla2AyU5V4iWOY1omDP1eMMNyCJ+U16PK4uFjmxmV+mCY1zLNa0tRz4P+hHT1TyY9hE/6WE8OM99DsHjPiJa+lJPMY=
       script:
-        - make crossbuild
-        - ln -s .build/linux-amd64/stackdriver_exporter stackdriver_exporter
         - |
           if [ -n "$TRAVIS_TAG" ]; then
             make docker DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME DOCKER_IMAGE_TAG=$TRAVIS_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
-FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  Ferran Rodenas <frodenas@gmail.com>
+###############################################################################
+# compile stage
+FROM golang:1.11
 
-COPY stackdriver_exporter /bin/stackdriver_exporter
+RUN mkdir -vp /go/src/github.com/frodenas/stackdriver_exporter/
+COPY . /go/src/github.com/frodenas/stackdriver_exporter
+# RUN go get -d github.com/frodenas/stackdriver_exporter
 
-ENTRYPOINT ["/bin/stackdriver_exporter"]
+RUN CGO_ENABLED=0 GOOS=linux go install github.com/frodenas/stackdriver_exporter
+
+###############################################################################
+# binary stage
+FROM alpine
+
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=0 /go/bin/stackdriver_exporter       /root/stackdriver_exporter
+
+ENTRYPOINT ["/root/stackdriver_exporter"]
 EXPOSE     9255

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ###############################################################################
 # compile stage
-FROM golang:1.11
+FROM golang:1.13-buster
 
 RUN mkdir -vp /go/src/github.com/frodenas/stackdriver_exporter/
 COPY . /go/src/github.com/frodenas/stackdriver_exporter


### PR DESCRIPTION
This provides a new Dockerfile that to the build from the source and a lightweight second stage with only the binary, resulting a 16.9Mb image.

    REPOSITORY                   TAG                 IMAGE ID            CREATED             SIZE
    prom_sdexporter              latest              df4f42ce3adb        13 minutes ago      16.9MB
