### PR TITLE
Use multi-arch Dockerfile

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,4 @@
-verbose: false
 go:
-  cgo: false
   # This must match .circle/config.yml.
   version: 1.14
 repository:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM        quay.io/prometheus/busybox:latest
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-COPY stackdriver_exporter /bin/stackdriver_exporter
+ARG ARCH="amd64"
+ARG OS="linux"
+COPY .build/${OS}-${ARCH}/stackdriver_exporter /bin/stackdriver_exporter
+COPY LICENSE /LICENSE
 
+USER       nobody
 ENTRYPOINT ["/bin/stackdriver_exporter"]
 EXPOSE     9255

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,20 @@
+# Copyright 2020 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needs to be defined before including Makefile.common to auto-generate targets
+DOCKER_ARCHS ?= amd64 armv7 arm64
+DOCKER_REPO  ?= prometheuscommunity
+
 include Makefile.common
 
 DOCKER_IMAGE_NAME       ?= stackdriver-exporter
-
-crossbuild: promu
-	@echo ">> building cross-platform binaries"
-	@$(PROMU) crossbuild

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ stackdriver_exporter <flags>
 To run the stackdriver exporter as a Docker container, run:
 
 ```console
-$ docker run -p 9255:9255 prometheus-community/stackdriver-exporter <flags>
+$ docker run -p 9255:9255 prometheuscommunity/stackdriver-exporter <flags>
 ```
 
 ### Cloud Foundry


### PR DESCRIPTION
Update Dockerfile and Makefile to support multi-arch images.
* Cleanup promu config.

Signed-off-by: Ben Kochie <superq@gmail.com>