### PR TITLE
Treat failure to collect metric as fatal

### DIFF
--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -187,7 +187,7 @@ func (c *MonitoringCollector) Collect(ch chan<- prometheus.Metric) {
 	if err := c.reportMonitoringMetrics(ch); err != nil {
 		errorMetric = float64(1)
 		c.scrapeErrorsTotalMetric.Inc()
-		log.Errorf("Error while getting Google Stackdriver Monitoring metrics: %s", err)
+		log.Fatalf("Error while getting Google Stackdriver Monitoring metrics: %s", err)
 	}
 	c.scrapeErrorsTotalMetric.Collect(ch)
 


### PR DESCRIPTION
Exit on any failure to collect metrics.  This will give
`stackdriver_exporter` a chance to start over and perhaps recover from
transient errors.  For example: if it's Google credentials have expired
and have been replaced, it can restart to try to load up new ones.

Closes #66 