### PR TITLE
Add metrics prefix collect URL param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
 
+* [FEATURE] Add metrics prefix collect URL param
+
 ## 0.7.0 / 2020-05-01
 
 * [CHANGE] Remove deprecated `monitoring.New()` use. #76

--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ stackdriver_exporter \
   --monitoring.metrics-type-prefixes "compute.googleapis.com/instance/cpu,compute.googleapis.com/instance/disk"
 ```
 
+## Filtering enabled collectors
+
+The `stackdriver_exporter` collects all metrics type prefixes by default.
+
+For advanced uses, the collection can be filtered by using a repeatable URL param called `collect[]`. In the Prometheus configuration you can use you can use this syntax under the [scrape config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<scrape_config>).
+
+
+```yaml
+params:
+  collect[]:
+  - compute.googleapis.com/instance/cpu
+  - compute.googleapis.com/instance/disk
+```
+
 ## Contributing
 
 Refer to the [contributing guidelines][contributing].

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -72,7 +72,7 @@ type MonitoringCollector struct {
 	monitoringDropDelegatedProjects bool
 }
 
-func NewMonitoringCollector(monitoringService *monitoring.Service) (*MonitoringCollector, error) {
+func NewMonitoringCollector(monitoringService *monitoring.Service, filters map[string]bool) (*MonitoringCollector, error) {
 	if *projectID == "" {
 		return nil, errors.New("Flag `google.project-id` is required")
 	}
@@ -141,9 +141,20 @@ func NewMonitoringCollector(monitoringService *monitoring.Service) (*MonitoringC
 		},
 	)
 
+	metricsTypePrefixes := strings.Split(*monitoringMetricsTypePrefixes, ",")
+	filteredPrefixes := metricsTypePrefixes
+	if len(filters) > 0 {
+		filteredPrefixes = nil
+		for _, prefix := range metricsTypePrefixes {
+			if filters[prefix] {
+				filteredPrefixes = append(filteredPrefixes, prefix)
+			}
+		}
+	}
+
 	monitoringCollector := &MonitoringCollector{
 		projectID:                       *projectID,
-		metricsTypePrefixes:             strings.Split(*monitoringMetricsTypePrefixes, ","),
+		metricsTypePrefixes:             filteredPrefixes,
 		metricsInterval:                 *monitoringMetricsInterval,
 		metricsOffset:                   *monitoringMetricsOffset,
 		monitoringService:               monitoringService,


### PR DESCRIPTION
Add URL param `collect[]` to allow requesting a filterd list of metrics.

Fixes: https://github.com/prometheus-community/stackdriver_exporter/issues/61

Signed-off-by: Ben Kochie <superq@gmail.com>