### PR TITLE
Fix collect param name

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ stackdriver_exporter \
 
 The `stackdriver_exporter` collects all metrics type prefixes by default.
 
-For advanced uses, the collection can be filtered by using a repeatable URL param called `collect[]`. In the Prometheus configuration you can use you can use this syntax under the [scrape config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<scrape_config>).
+For advanced uses, the collection can be filtered by using a repeatable URL param called `collect`. In the Prometheus configuration you can use you can use this syntax under the [scrape config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<scrape_config>).
 
 
 ```yaml
 params:
-  collect[]:
+  collect:
   - compute.googleapis.com/instance/cpu
   - compute.googleapis.com/instance/disk
 ```

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -96,9 +96,9 @@ func createMonitoringService() (*monitoring.Service, error) {
 
 func newHandler(m *monitoring.Service, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		collectParams := r.URL.Query()["collect[]"]
+		collectParams := r.URL.Query()["collect"]
 
-		// Create filters for "collect[]" query parameters.
+		// Create filters for "collect" query parameters.
 		filters := make(map[string]bool)
 		for _, param := range collectParams {
 			filters[param] = true


### PR DESCRIPTION
Don't use `[]` in the collect param name, avoids Prometheus relabeling
issue with `__param_collect[]` being "invalid" as a target label.

Signed-off-by: Ben Kochie <superq@gmail.com>