### PR TITLE
add monitoring.filters flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If you are still using the legacy [Access scopes][access-scopes], the `https://w
 | `monitoring.metrics-type-prefixes`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES` | Yes | | Comma separated Google Stackdriver Monitoring Metric Type prefixes (see [example][metrics-prefix-example] and [available metrics][metrics-list]) |
 | `monitoring.metrics-interval`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL` | No | `5m` | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |
 | `monitoring.metrics-offset`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET` | No | `0s` | Offset (into the past) for the metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API, to handle latency in published metrics |
+| `monitoring.metrics-extra-filter` | No | Empty list | Formatted string to allow extra filtering on certain metrics type |
 | `web.listen-address`<br />`STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS` | No | `:9255` | Address to listen on for web interface and telemetry |
 | `web.telemetry-path`<br />`STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH` | No | `/metrics` | Path under which to expose Prometheus metrics |
 
@@ -105,6 +106,15 @@ If we want to get all `CPU` (`compute.googleapis.com/instance/cpu`) and `Disk` (
 stackdriver_exporter \
   --google.project-id my-test-project \
   --monitoring.metrics-type-prefixes "compute.googleapis.com/instance/cpu,compute.googleapis.com/instance/disk"
+```
+
+Using extra filters:
+
+```
+stackdriver_exporter \
+ --google.project-id my-test-project \
+ --monitoring.metrics-type-prefixes='pubsub.googleapis.com/subscription' \
+ --monitoring.metrics-extra-filter='pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match("us-west4.*my-team-subs.*")'
 ```
 
 ## Filtering enabled collectors

--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ If you are still using the legacy [Access scopes][access-scopes], the `https://w
 
 ### Flags
 
-| Flag / Environment Variable | Required | Default | Description |
-| --------------------------- | -------- | ------- | ----------- |
-| `google.project-id`<br />`STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID` | No | GCloud SDK autodiscovery | Comma seperated list of Google Project IDs |
+| Flag / Environment Variable                                                                     | Required | Default | Description |
+|-------------------------------------------------------------------------------------------------| -------- | ------- | ----------- |
+| `google.project-id`<br />`STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID`                               | No | GCloud SDK autodiscovery | Comma seperated list of Google Project IDs |
 | `monitoring.metrics-type-prefixes`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES` | Yes | | Comma separated Google Stackdriver Monitoring Metric Type prefixes (see [example][metrics-prefix-example] and [available metrics][metrics-list]) |
-| `monitoring.metrics-interval`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL` | No | `5m` | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |
-| `monitoring.metrics-offset`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET` | No | `0s` | Offset (into the past) for the metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API, to handle latency in published metrics |
-| `monitoring.metrics-extra-filter` | No | Empty list | Formatted string to allow extra filtering on certain metrics type |
-| `web.listen-address`<br />`STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS` | No | `:9255` | Address to listen on for web interface and telemetry |
-| `web.telemetry-path`<br />`STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH` | No | `/metrics` | Path under which to expose Prometheus metrics |
+| `monitoring.metrics-interval`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL`           | No | `5m` | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |
+| `monitoring.metrics-offset`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET`               | No | `0s` | Offset (into the past) for the metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API, to handle latency in published metrics |
+| `monitoring.filters`| No | Empty list | Formatted string to allow filtering on certain metrics type |
+| `web.listen-address`<br />`STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS`                             | No | `:9255` | Address to listen on for web interface and telemetry |
+| `web.telemetry-path`<br />`STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH`                             | No | `/metrics` | Path under which to expose Prometheus metrics |
 
 ### Metrics
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you are still using the legacy [Access scopes][access-scopes], the `https://w
 ### Flags
 
 | Flag / Environment Variable | Required | Default | Description |
-| -------- | -------- | ------- | ----------- |
+| --------------------------- | -------- | ------- | ----------- |
 | `google.project-id`<br />`STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID` | No | GCloud SDK autodiscovery | Comma seperated list of Google Project IDs |
 | `monitoring.metrics-type-prefixes`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES` | Yes | | Comma separated Google Stackdriver Monitoring Metric Type prefixes (see [example][metrics-prefix-example] and [available metrics][metrics-list]) |
 | `monitoring.metrics-interval`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL` | No | `5m` | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |

--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ If you are still using the legacy [Access scopes][access-scopes], the `https://w
 
 ### Flags
 
-| Flag / Environment Variable                                                                     | Required | Default | Description |
-|-------------------------------------------------------------------------------------------------| -------- | ------- | ----------- |
-| `google.project-id`<br />`STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID`                               | No | GCloud SDK autodiscovery | Comma seperated list of Google Project IDs |
+| Flag / Environment Variable | Required | Default | Description |
+| -------- | -------- | ------- | ----------- |
+| `google.project-id`<br />`STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID` | No | GCloud SDK autodiscovery | Comma seperated list of Google Project IDs |
 | `monitoring.metrics-type-prefixes`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES` | Yes | | Comma separated Google Stackdriver Monitoring Metric Type prefixes (see [example][metrics-prefix-example] and [available metrics][metrics-list]) |
-| `monitoring.metrics-interval`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL`           | No | `5m` | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |
-| `monitoring.metrics-offset`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET`               | No | `0s` | Offset (into the past) for the metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API, to handle latency in published metrics |
+| `monitoring.metrics-interval`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL` | No | `5m` | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |
+| `monitoring.metrics-offset`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET` | No | `0s` | Offset (into the past) for the metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API, to handle latency in published metrics |
 | `monitoring.filters`| No | Empty list | Formatted string to allow filtering on certain metrics type |
-| `web.listen-address`<br />`STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS`                             | No | `:9255` | Address to listen on for web interface and telemetry |
-| `web.telemetry-path`<br />`STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH`                             | No | `/metrics` | Path under which to expose Prometheus metrics |
+| `web.listen-address`<br />`STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS` | No | `:9255` | Address to listen on for web interface and telemetry |
+| `web.telemetry-path`<br />`STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH` | No | `/metrics` | Path under which to expose Prometheus metrics |
 
 ### Metrics
 

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -246,16 +245,10 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 				}
 				if len(c.monitoringExtraFilter) > 0 {
 					for _, ef := range c.monitoringExtraFilter {
-						mPrefix := strings.Split(ef, ":")
-						if len(mPrefix) == 0 {
-							continue
-						}
-						if strings.Contains(metricDescriptor.Type, mPrefix[0]) {
-							m := regexp.MustCompile(mPrefix[0])
-							extraFilter := m.ReplaceAllString(ef, "")
-							extraFilter = strings.Replace(extraFilter, ":", "", 1)
-							filter = fmt.Sprintf("%s AND (%s)", filter, extraFilter)
-							level.Debug(c.logger).Log("msg", "adding extra metrics filter", filter)
+						efPrefix, efModifier := utils.GetExtraFilterModifiers(ef, ":")
+						if efPrefix != "" && strings.Contains(metricDescriptor.Type, efPrefix) {
+							filter = fmt.Sprintf("%s AND (%s)", filter, efModifier)
+							level.Debug(c.logger).Log("msg", "adding extra metrics filter", "descriptor", filter)
 						}
 					}
 				}

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -150,7 +150,6 @@ func NewMonitoringCollector(projectID string, monitoringService *monitoring.Serv
 		}
 	}
 
-
 	monitoringCollector := &MonitoringCollector{
 		projectID:                       projectID,
 		metricsTypePrefixes:             filteredPrefixes,

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -53,7 +53,7 @@ var (
 	).Envar("STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS").Default("false").Bool()
 
 	monitoringExtraFilter = kingpin.Flag(
-		"monitoring.extra.filter", "Extra filters. i.e: pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match(\"my-subs-prefix.*\")").Strings()
+		"monitoring.metrics-extra-filter", "Extra filters. i.e: pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match(\"my-subs-prefix.*\")").Strings()
 )
 
 type MonitoringExtraFilter struct {

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -53,7 +53,7 @@ var (
 	).Envar("STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS").Default("false").Bool()
 
 	monitoringExtraFilter = kingpin.Flag(
-		"monitoring.extra.filter", "Extra filters. i.e: resource.labels.subscription_id=monitoring.regex.full_match(\"my-subs-prefix.*\")").Strings()
+		"monitoring.extra.filter", "Extra filters. i.e: pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match(\"my-subs-prefix.*\")").Strings()
 )
 
 type MonitoringExtraFilter struct {

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -53,13 +53,13 @@ var (
 	).Envar("STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS").Default("false").Bool()
 
 	monitoringExtraFilters = kingpin.Flag(
-		"monitoring.extra.filter", "Extra filters. i.e: resource.labels.subscription_id=monitoring.regex.full_match(\"my-subs-prefix.*\")").Strings()
+		"monitoring.extra.filters", "Extra filters. i.e: resource.labels.subscription_id=monitoring.regex.full_match(\"my-subs-prefix.*\")").Default("").String()
 )
 
 type MonitoringCollector struct {
 	projectID                       string
 	metricsTypePrefixes             []string
-	monitoringExtraFilters          []string
+	monitoringExtraFilters          string
 	metricsInterval                 time.Duration
 	metricsOffset                   time.Duration
 	monitoringService               *monitoring.Service
@@ -243,10 +243,8 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 						c.projectID,
 						metricDescriptor.Type)
 				}
-				if len(c.monitoringExtraFilters) > 0 {
-					for _, extraFilter := range c.monitoringExtraFilters {
-						filter = fmt.Sprintf("%s AND %s", filter, extraFilter)
-					}
+				if *monitoringExtraFilters != ""{
+					filter = fmt.Sprintf("%s AND (%s)", filter, *monitoringExtraFilters)
 				}
 				level.Debug(c.logger).Log("msg", "retrieving Google Stackdriver Monitoring metrics with filter", "filter", filter)
 

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -259,15 +259,13 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 						c.projectID,
 						metricDescriptor.Type)
 				}
-				if len(c.monitoringExtraFilter) > 0 {
-					for _, ef := range c.monitoringExtraFilter {
-						if strings.Contains(metricDescriptor.Type, ef.Prefix) {
-							filter = fmt.Sprintf("%s AND (%s)", filter, ef.Modifier)
-						}
+				for _, ef := range c.monitoringExtraFilter {
+					if strings.Contains(metricDescriptor.Type, ef.Prefix) {
+						filter = fmt.Sprintf("%s AND (%s)", filter, ef.Modifier)
 					}
 				}
-				level.Debug(c.logger).Log("msg", "retrieving Google Stackdriver Monitoring metrics with filter", "filter", filter)
 
+				level.Debug(c.logger).Log("msg", "retrieving Google Stackdriver Monitoring metrics with filter", "filter", filter)
 				timeSeriesListCall := c.monitoringService.Projects.TimeSeries.List(utils.ProjectResource(c.projectID)).
 					Filter(filter).
 					IntervalStartTime(startTime.Format(time.RFC3339Nano)).

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -159,7 +159,7 @@ func NewMonitoringCollector(projectID string, monitoringService *monitoring.Serv
 		efPrefix, efModifier := utils.GetExtraFilterModifiers(ef, ":")
 		if efPrefix != "" {
 			extraFilter := MetricExtraFilter{
-				Prefix: efPrefix,
+				Prefix:   efPrefix,
 				Modifier: efModifier,
 			}
 			extraFilters = append(extraFilters, extraFilter)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -39,6 +39,15 @@ func NormalizeMetricName(metricName string) string {
 	return strings.Join(normalizedMetricName, "_")
 }
 
+func GetExtraFilterModifiers(extraFilter string, separator string) (string, string) {
+	mPrefix := strings.Split(extraFilter, separator)
+	if mPrefix[0] == extraFilter {
+		return "", ""
+	}
+	return mPrefix[0], strings.Join(mPrefix[1:], "")
+}
+
+
 func ProjectResource(projectID string) string {
 	return "projects/" + projectID
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -47,7 +47,6 @@ func GetExtraFilterModifiers(extraFilter string, separator string) (string, stri
 	return mPrefix[0], strings.Join(mPrefix[1:], "")
 }
 
-
 func ProjectResource(projectID string) string {
 	return "projects/" + projectID
 }


### PR DESCRIPTION
## What does this change do?
Add `monitoring.filters` flag

## Why is it needed?
Allow more granularity when requesting for time series list by letting developers refine their metrics by using Filter objects that Google provides. 

```
Filter objects: project, group.id, resource.type, resource.labels.[KEY], metric.type, metric.labels.[KEY]
```
https://cloud.google.com/monitoring/api/v3/filters


## Example

```
go run stackdriver_exporter.go \
  --google.project-id=my-project \
  --monitoring.metrics-type-prefixes='pubsub.googleapis.com/subscription/num_undelivered_messages,redis.googleapis.com' \
  --monitoring.filters='pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match("us-west4.*my-team.*")'
```