### PR TITLE
Cleanup non-standard ENV var setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## master / unreleased
 
+Breaking Changes:
+
+The exporter nolonger supports configuration via ENV vars. This was a non-standard feature that is not part of the Prometheus ecossystem. All configuration is now handled by the existing command line arguments.
+
+* [CHANGE] Cleanup non-standard ENV var setup #142
+
 ## 0.11.0 / 2020-09-02
 
 * [CHANGE] Do not treat failure to collect metrics as fatal #102

--- a/README.md
+++ b/README.md
@@ -61,15 +61,15 @@ If you are still using the legacy [Access scopes][access-scopes], the `https://w
 
 ### Flags
 
-| Flag / Environment Variable | Required | Default | Description |
-| --------------------------- | -------- | ------- | ----------- |
-| `google.project-id`<br />`STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID` | No | GCloud SDK autodiscovery | Comma seperated list of Google Project IDs |
-| `monitoring.metrics-type-prefixes`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES` | Yes | | Comma separated Google Stackdriver Monitoring Metric Type prefixes (see [example][metrics-prefix-example] and [available metrics][metrics-list]) |
-| `monitoring.metrics-interval`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL` | No | `5m` | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |
-| `monitoring.metrics-offset`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET` | No | `0s` | Offset (into the past) for the metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API, to handle latency in published metrics |
-| `monitoring.filters`| No | Empty list | Formatted string to allow filtering on certain metrics type |
-| `web.listen-address`<br />`STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS` | No | `:9255` | Address to listen on for web interface and telemetry |
-| `web.telemetry-path`<br />`STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH` | No | `/metrics` | Path under which to expose Prometheus metrics |
+| Flag                              | Required | Default | Description |
+| --------------------------------- | -------- | ------- | ----------- |
+| `google.project-id`               | No       | GCloud SDK auto-discovery | Comma seperated list of Google Project IDs |
+| `monitoring.metrics-type-prefixes | Yes      |         | Comma separated Google Stackdriver Monitoring Metric Type prefixes (see [example][metrics-prefix-example] and [available metrics][metrics-list]) |
+| `monitoring.metrics-interval`     | No       | `5m`    | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |
+| `monitoring.metrics-offset`       | No       | `0s`    | Offset (into the past) for the metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API, to handle latency in published metrics |
+| `monitoring.filters`              | No       |         | Formatted string to allow filtering on certain metrics type |
+| `web.listen-address`              | No       | `:9255` | Address to listen on for web interface and telemetry |
+| `web.telemetry-path`              | No       | `/metrics` | Path under which to expose Prometheus metrics |
 
 ### Metrics
 

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -33,24 +33,24 @@ import (
 
 var (
 	monitoringMetricsTypePrefixes = kingpin.Flag(
-		"monitoring.metrics-type-prefixes", "Comma separated Google Stackdriver Monitoring Metric Type prefixes ($STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES).",
-	).Envar("STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES").Required().String()
+		"monitoring.metrics-type-prefixes", "Comma separated Google Stackdriver Monitoring Metric Type prefixes.",
+	).Required().String()
 
 	monitoringMetricsInterval = kingpin.Flag(
-		"monitoring.metrics-interval", "Interval to request the Google Stackdriver Monitoring Metrics for. Only the most recent data point is used ($STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL).",
-	).Envar("STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL").Default("5m").Duration()
+		"monitoring.metrics-interval", "Interval to request the Google Stackdriver Monitoring Metrics for. Only the most recent data point is used.",
+	).Default("5m").Duration()
 
 	monitoringMetricsOffset = kingpin.Flag(
-		"monitoring.metrics-offset", "Offset for the Google Stackdriver Monitoring Metrics interval into the past ($STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET).",
-	).Envar("STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET").Default("0s").Duration()
+		"monitoring.metrics-offset", "Offset for the Google Stackdriver Monitoring Metrics interval into the past.",
+	).Default("0s").Duration()
 
 	collectorFillMissingLabels = kingpin.Flag(
-		"collector.fill-missing-labels", "Fill missing metrics labels with empty string to avoid label dimensions inconsistent failure ($STACKDRIVER_EXPORTER_COLLECTOR_FILL_MISSING_LABELS).",
-	).Envar("STACKDRIVER_EXPORTER_COLLECTOR_FILL_MISSING_LABELS").Default("true").Bool()
+		"collector.fill-missing-labels", "Fill missing metrics labels with empty string to avoid label dimensions inconsistent failure.",
+	).Default("true").Bool()
 
 	monitoringDropDelegatedProjects = kingpin.Flag(
-		"monitoring.drop-delegated-projects", "Drop metrics from attached projects and fetch `project_id` only ($STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS).",
-	).Envar("STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS").Default("false").Bool()
+		"monitoring.drop-delegated-projects", "Drop metrics from attached projects and fetch `project_id` only.",
+	).Default("false").Bool()
 
 	monitoringMetricsExtraFilter = kingpin.Flag(
 		"monitoring.filters", "Filters. i.e: pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match(\"my-subs-prefix.*\")").Strings()

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,9 +1,0 @@
----
-applications:
-  - name: stackdriver-exporter
-    buildpack: go_buildpack
-    env:
-      GOPACKAGENAME: github.com/prometheus-community/stackdriver_exporter
-      GOOGLE_APPLICATION_CREDENTIALS: "The file location that defines your Google Credentials"
-      STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID: "Your Google Project ID"
-      STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIX: "The desired Google Stackdriver Monitoring Metrics Type prefix"

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -39,36 +39,36 @@ import (
 
 var (
 	listenAddress = kingpin.Flag(
-		"web.listen-address", "Address to listen on for web interface and telemetry ($STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS).",
-	).Envar("STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS").Default(":9255").String()
+		"web.listen-address", "Address to listen on for web interface and telemetry.",
+	).Default(":9255").String()
 
 	metricsPath = kingpin.Flag(
-		"web.telemetry-path", "Path under which to expose Prometheus metrics ($STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH).",
-	).Envar("STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH").Default("/metrics").String()
+		"web.telemetry-path", "Path under which to expose Prometheus metrics.",
+	).Default("/metrics").String()
 
 	projectID = kingpin.Flag(
-		"google.project-id", "Comma seperated list of Google Project IDs ($STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID).",
-	).Envar("STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID").String()
+		"google.project-id", "Comma seperated list of Google Project IDs.",
+	).String()
 
 	stackdriverMaxRetries = kingpin.Flag(
-		"stackdriver.max-retries", "Max number of retries that should be attempted on 503 errors from stackdriver. ($STACKDRIVER_EXPORTER_MAX_RETRIES)",
-	).Envar("STACKDRIVER_EXPORTER_MAX_RETRIES").Default("0").Int()
+		"stackdriver.max-retries", "Max number of retries that should be attempted on 503 errors from stackdriver.",
+	).Default("0").Int()
 
 	stackdriverHttpTimeout = kingpin.Flag(
-		"stackdriver.http-timeout", "How long should stackdriver_exporter wait for a result from the Stackdriver API ($STACKDRIVER_EXPORTER_HTTP_TIMEOUT)",
-	).Envar("STACKDRIVER_EXPORTER_HTTP_TIMEOUT").Default("10s").Duration()
+		"stackdriver.http-timeout", "How long should stackdriver_exporter wait for a result from the Stackdriver API.",
+	).Default("10s").Duration()
 
 	stackdriverMaxBackoffDuration = kingpin.Flag(
-		"stackdriver.max-backoff", "Max time between each request in an exp backoff scenario ($STACKDRIVER_EXPORTER_MAX_BACKOFF_DURATION)",
-	).Envar("STACKDRIVER_EXPORTER_MAX_BACKOFF_DURATION").Default("5s").Duration()
+		"stackdriver.max-backoff", "Max time between each request in an exp backoff scenario.",
+	).Default("5s").Duration()
 
 	stackdriverBackoffJitterBase = kingpin.Flag(
-		"stackdriver.backoff-jitter", "The amount of jitter to introduce in a exp backoff scenario ($STACKDRIVER_EXPORTER_BACKODFF_JITTER_BASE)",
-	).Envar("STACKDRIVER_EXPORTER_BACKODFF_JITTER_BASE").Default("1s").Duration()
+		"stackdriver.backoff-jitter", "The amount of jitter to introduce in a exp backoff scenario.",
+	).Default("1s").Duration()
 
 	stackdriverRetryStatuses = kingpin.Flag(
-		"stackdriver.retry-statuses", "The HTTP statuses that should trigger a retry ($STACKDRIVER_EXPORTER_RETRY_STATUSES)",
-	).Envar("STACKDRIVER_EXPORTER_RETRY_STATUSES").Default("503").Ints()
+		"stackdriver.retry-statuses", "The HTTP statuses that should trigger a retry.",
+	).Default("503").Ints()
 )
 
 func init() {


### PR DESCRIPTION
Drop ENV vars from flags as this is non-standard in the Prometheus
ecosystem.
* Drop extraneous manifest.yml.

Signed-off-by: SuperQ <superq@gmail.com>