### PR TITLE
Fix the example filter arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Using extra filters:
 stackdriver_exporter \
  --google.project-id my-test-project \
  --monitoring.metrics-type-prefixes='pubsub.googleapis.com/subscription' \
- --monitoring.metrics-extra-filter='pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match("us-west4.*my-team-subs.*")'
+ --monitoring.filters='pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match("us-west4.*my-team-subs.*")'
 ```
 
 ## Filtering enabled collectors


### PR DESCRIPTION
In https://github.com/prometheus-community/stackdriver_exporter/pull/133 filtering was added but the example in the README was still referencing an old style arg. 