### PR TITLE
Metrics-ingest-delay bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ If you are still using the legacy [Access scopes][access-scopes], the `https://w
 | Flag                              | Required | Default | Description |
 | --------------------------------- | -------- | ------- | ----------- |
 | `google.project-id`               | No       | GCloud SDK auto-discovery | Comma seperated list of Google Project IDs |
+| `monitoring.metrics-ingest-delay` | No       |         | Offsets metric collection by a delay appropriate for each metric type, e.g. because bigquery metrics are slow to appear |
 | `monitoring.metrics-type-prefixes | Yes      |         | Comma separated Google Stackdriver Monitoring Metric Type prefixes (see [example][metrics-prefix-example] and [available metrics][metrics-list]) |
 | `monitoring.metrics-interval`     | No       | `5m`    | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |
 | `monitoring.metrics-offset`       | No       | `0s`    | Offset (into the past) for the metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API, to handle latency in published metrics |
 | `monitoring.filters`              | No       |         | Formatted string to allow filtering on certain metrics type |
 | `web.listen-address`              | No       | `:9255` | Address to listen on for web interface and telemetry |
 | `web.telemetry-path`              | No       | `/metrics` | Path under which to expose Prometheus metrics |
-| `monitoring.metrics-ingest-delay` | No       |         | Offsets metric collection by a delay appropriate for each metric type, e.g. because bigquery metrics are slow to appear |
 
 ### Metrics
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If you are still using the legacy [Access scopes][access-scopes], the `https://w
 | `monitoring.filters`              | No       |         | Formatted string to allow filtering on certain metrics type |
 | `web.listen-address`              | No       | `:9255` | Address to listen on for web interface and telemetry |
 | `web.telemetry-path`              | No       | `/metrics` | Path under which to expose Prometheus metrics |
+| `monitoring.metrics-ingest-delay` | No       |         | Offsets metric collection by a delay appropriate for each metric type, e.g. because bigquery metrics are slow to appear |
 
 ### Metrics
 

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -266,6 +266,11 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 						metricDescriptor.Type)
 				}
 
+				if metricDescriptor.DisplayName == "Stored bytes" {
+					fmt.Printf("\n start pre \n %+v \n\n\n\n", startTime.Format(time.RFC3339Nano))
+					fmt.Printf("\n\n end pre \n %+v \n\n\n\n", endTime.Format(time.RFC3339Nano))
+				}
+
 				if c.metricsIngestDelay &&
 					metricDescriptor.Metadata != nil &&
 					metricDescriptor.Metadata.IngestDelay != "" {
@@ -277,10 +282,14 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 						return
 					}
 					level.Debug(c.logger).Log("msg", "adding ingest delay", "descriptor", metricDescriptor.Type, "delay", ingestDelay)
-					endTime.Add(ingestDelayDuration)
-					startTime.Add(ingestDelayDuration)
+					endTime = endTime.Add(ingestDelayDuration * -1)
+					startTime = startTime.Add(ingestDelayDuration * -1)
 				}
 
+				if metricDescriptor.DisplayName == "Stored bytes" {
+					fmt.Printf("\n start post \n %+v \n\n\n\n", startTime.Format(time.RFC3339Nano))
+					fmt.Printf("\n\n end post \n %+v \n\n\n\n", endTime.Format(time.RFC3339Nano))
+				}
 				for _, ef := range c.metricsFilters {
 					if strings.Contains(metricDescriptor.Type, ef.Prefix) {
 						filter = fmt.Sprintf("%s AND (%s)", filter, ef.Modifier)
@@ -356,6 +365,7 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 }
 
 func (c *MonitoringCollector) reportTimeSeriesMetrics(
+
 	page *monitoring.ListTimeSeriesResponse,
 	metricDescriptor *monitoring.MetricDescriptor,
 	ch chan<- prometheus.Metric,

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -266,11 +266,6 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 						metricDescriptor.Type)
 				}
 
-				if metricDescriptor.DisplayName == "Stored bytes" {
-					fmt.Printf("\n start pre \n %+v \n\n\n\n", startTime.Format(time.RFC3339Nano))
-					fmt.Printf("\n\n end pre \n %+v \n\n\n\n", endTime.Format(time.RFC3339Nano))
-				}
-
 				if c.metricsIngestDelay &&
 					metricDescriptor.Metadata != nil &&
 					metricDescriptor.Metadata.IngestDelay != "" {
@@ -286,10 +281,6 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 					startTime = startTime.Add(ingestDelayDuration * -1)
 				}
 
-				if metricDescriptor.DisplayName == "Stored bytes" {
-					fmt.Printf("\n start post \n %+v \n\n\n\n", startTime.Format(time.RFC3339Nano))
-					fmt.Printf("\n\n end post \n %+v \n\n\n\n", endTime.Format(time.RFC3339Nano))
-				}
 				for _, ef := range c.metricsFilters {
 					if strings.Contains(metricDescriptor.Type, ef.Prefix) {
 						filter = fmt.Sprintf("%s AND (%s)", filter, ef.Modifier)
@@ -365,7 +356,6 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 }
 
 func (c *MonitoringCollector) reportTimeSeriesMetrics(
-
 	page *monitoring.ListTimeSeriesResponse,
 	metricDescriptor *monitoring.MetricDescriptor,
 	ch chan<- prometheus.Metric,


### PR DESCRIPTION
We noticed that with `metrics-ingest-delay` flag set the exporter fails to apply the time offset as expected, despite what the debug log prints. The root cause appears to be failing to assign back the start and end times back to the original target as indicated in my PR below. 

I've dropped the fmt.Printf statements that allowed us to locate the bug, but feel free to revert my second commit locally to reproduce the issue. You might need to change the IF conditional from Stored bytes, a BigQuery metric, to another similar metric depending on what project you use for testing and what APIs you have available there.

I also added the feature to the README since it seems to be good to go otherwise!