### PR TITLE
Fixes suspected duplicate label panic for some GCP metric

### DIFF
--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -389,7 +389,7 @@ func (c *MonitoringCollector) reportTimeSeriesMetrics(
 		// Add the metric labels
 		// @see https://cloud.google.com/monitoring/api/metrics
 		for key, value := range timeSeries.Metric.Labels {
-			if !keyExists(labelKeys, key) {
+			if !c.keyExists(labelKeys, key) {
 				labelKeys = append(labelKeys, key)
 				labelValues = append(labelValues, value)
 			}
@@ -398,7 +398,7 @@ func (c *MonitoringCollector) reportTimeSeriesMetrics(
 		// Add the monitored resource labels
 		// @see https://cloud.google.com/monitoring/api/resources
 		for key, value := range timeSeries.Resource.Labels {
-			if !keyExists(labelKeys, key) {
+			if !c.keyExists(labelKeys, key) {
 				labelKeys = append(labelKeys, key)
 				labelValues = append(labelValues, value)
 			}
@@ -511,9 +511,10 @@ func (c *MonitoringCollector) generateHistogramBuckets(
 	return buckets, nil
 }
 
-func keyExists(labelKeys []string, key string) bool {
+func (c *MonitoringCollector) keyExists(labelKeys []string, key string) bool {
 	for _, item := range labelKeys {
 		if item == key {
+			level.Debug(c.logger).Log("msg", "Found duplicate label key", "key", key)
 			return true
 		}
 	}

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -389,15 +389,19 @@ func (c *MonitoringCollector) reportTimeSeriesMetrics(
 		// Add the metric labels
 		// @see https://cloud.google.com/monitoring/api/metrics
 		for key, value := range timeSeries.Metric.Labels {
-			labelKeys = append(labelKeys, key)
-			labelValues = append(labelValues, value)
+			if !keyExists(labelKeys, key) {
+				labelKeys = append(labelKeys, key)
+				labelValues = append(labelValues, value)
+			}
 		}
 
 		// Add the monitored resource labels
 		// @see https://cloud.google.com/monitoring/api/resources
 		for key, value := range timeSeries.Resource.Labels {
-			labelKeys = append(labelKeys, key)
-			labelValues = append(labelValues, value)
+			if !keyExists(labelKeys, key) {
+				labelKeys = append(labelKeys, key)
+				labelValues = append(labelValues, value)
+			}
 		}
 
 		if c.monitoringDropDelegatedProjects {
@@ -505,4 +509,13 @@ func (c *MonitoringCollector) generateHistogramBuckets(
 		}
 	}
 	return buckets, nil
+}
+
+func keyExists(labelKeys []string, key string) bool {
+	for _, item := range labelKeys {
+		if item == key {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Metric like `istio.io/control` were failing because `mesh_id` and some other labels were added multiple times