### PR TITLE
Fix data race on metricDescriptorsFunction start and end times

### DIFF
--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -255,7 +255,7 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 
 		for _, metricDescriptor := range uniqueDescriptors {
 			wg.Add(1)
-			go func(metricDescriptor *monitoring.MetricDescriptor, ch chan<- prometheus.Metric) {
+			go func(metricDescriptor *monitoring.MetricDescriptor, ch chan<- prometheus.Metric, startTime, endTime time.Time) {
 				defer wg.Done()
 				level.Debug(c.logger).Log("msg", "retrieving Google Stackdriver Monitoring metrics for descriptor", "descriptor", metricDescriptor.Type)
 				filter := fmt.Sprintf("metric.type=\"%s\"", metricDescriptor.Type)
@@ -315,7 +315,7 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 					}
 					timeSeriesListCall.PageToken(page.NextPageToken)
 				}
-			}(metricDescriptor, ch)
+			}(metricDescriptor, ch, startTime, endTime)
 		}
 
 		wg.Wait()


### PR DESCRIPTION
Doing some trials with the exporter, I found a data race condition in the go-routines launched by each `metricDescriptorsFunction` when about to pull time series.

The raw stacktrace goes as follows:
```
==================
WARNING: DATA RACE
Write at 0x00c00000f7b8 by goroutine 104:
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func1.1()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:245 +0x834
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func1.2()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:283 +0x58

Previous read at 0x00c00000f7b8 by goroutine 41:
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func1.1()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:260 +0x1240
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func1.2()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:283 +0x58

Goroutine 104 (running) created at:
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func1()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:223 +0x3c8
level=debug ts=2022-05-19T15:42:57.467941Z revision=fd8d54ee-WIP caller=monitoring_collector.go:255 traceID=1272ddad166d68b1 instance_id=123 metrics_id=123 job_name=holis msg="retrieving Google Stackdriver Monitoring metrics with filter" filter="project=\"wired-height-350515\" AND metric.type=\"serviceruntime.googleapis.com/api/request_latencies_backend\""
  google.golang.org/api/monitoring/v3.(*ProjectsMetricDescriptorsListCall).Pages()
      /Users/pablo/go/pkg/mod/google.golang.org/api@v0.75.0/monitoring/v3/monitoring-gen.go:10545 +0x180
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func2()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:311 +0x564
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func3()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:314 +0x58

Goroutine 41 (running) created at:
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func1()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:223 +0x3c8
  google.golang.org/api/monitoring/v3.(*ProjectsMetricDescriptorsListCall).Pages()
      /Users/pablo/go/pkg/mod/google.golang.org/api@v0.75.0/monitoring/v3/monitoring-gen.go:10545 +0x180
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func2()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:311 +0x564
  github.com/prometheus-community/stackdriver_exporter/collectors.(*MonitoringCollector).reportMonitoringMetrics.func3()
      /Users/pablo/work/stackdriver_exporter/collectors/monitoring_collector.go:314 +0x58

``` 

Diving a bit deeper, the data race arises when one go routine, launched [here](https://github.com/prometheus-community/stackdriver_exporter/blob/master/collectors/monitoring_collector.go#L258), [tries to write](https://github.com/prometheus-community/stackdriver_exporter/blob/master/collectors/monitoring_collector.go#L280)  the `endTime ` object; while another one [attempts to read](https://github.com/prometheus-community/stackdriver_exporter/blob/master/collectors/monitoring_collector.go#L295) `endTime`. Since the `endTime` date object is shared across all go-routines this leads to a data race. 
This is easily fixed by passing both `startTime` and `endTime` by copy to each `MetricsDescriptor` processor go-routine.

Notice that this problem ONLY happens if the ingest delay flag is turned on, because the offending write path is [flagged with it](https://github.com/prometheus-community/stackdriver_exporter/blob/master/collectors/monitoring_collector.go#L269).