### PR TITLE
Add more info about filters to docs and rename struct fields

### DIFF
--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -33,8 +33,8 @@ import (
 const namespace = "stackdriver"
 
 type MetricFilter struct {
-	Prefix   string
-	Modifier string
+	TargetedMetricPrefix string
+	FilterQuery          string
 }
 
 type MonitoringCollector struct {
@@ -306,8 +306,8 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 				}
 
 				for _, ef := range c.metricsFilters {
-					if strings.Contains(metricDescriptor.Type, ef.Prefix) {
-						filter = fmt.Sprintf("%s AND (%s)", filter, ef.Modifier)
+					if strings.Contains(metricDescriptor.Type, ef.TargetedMetricPrefix) {
+						filter = fmt.Sprintf("%s AND (%s)", filter, ef.FilterQuery)
 					}
 				}
 

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -306,7 +306,7 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 				}
 
 				for _, ef := range c.metricsFilters {
-					if strings.Contains(metricDescriptor.Type, ef.TargetedMetricPrefix) {
+					if strings.HasPrefix(metricDescriptor.Type, ef.TargetedMetricPrefix) {
 						filter = fmt.Sprintf("%s AND (%s)", filter, ef.FilterQuery)
 					}
 				}

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -279,7 +279,14 @@ func main() {
 		}
 	}
 
-	level.Info(logger).Log("msg", "Starting stackdriver_exporter", "version", version.Info())
+	level.Info(logger).Log(
+		"msg", "Starting stackdriver_exporter",
+		"version", version.Info(),
+		"build_context", version.BuildContext(),
+		"projects", *projectID,
+		"metric_prefixes", *monitoringMetricsTypePrefixes,
+		"extra_filters", strings.Join(*monitoringMetricsExtraFilter, ","),
+	)
 	level.Info(logger).Log("msg", "Build context", "build_context", version.BuildContext())
 
 	monitoringService, err := createMonitoringService(ctx)

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -368,7 +368,7 @@ func parseMetricExtraFilters() []collectors.MetricFilter {
 		targetedMetricPrefix, filterQuery := utils.SplitExtraFilter(ef, ":")
 		if targetedMetricPrefix != "" {
 			extraFilter := collectors.MetricFilter{
-				TargetedMetricPrefix: targetedMetricPrefix,
+				TargetedMetricPrefix: strings.ToLower(targetedMetricPrefix),
 				FilterQuery:          filterQuery,
 			}
 			extraFilters = append(extraFilters, extraFilter)

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -110,7 +110,9 @@ var (
 	).Default("false").Bool()
 
 	monitoringMetricsExtraFilter = kingpin.Flag(
-		"monitoring.filters", "Filters. i.e: pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match(\"my-subs-prefix.*\")").Strings()
+		"monitoring.filters",
+		"Filters. i.e: pubsub.googleapis.com/subscription:resource.labels.subscription_id=monitoring.regex.full_match(\"my-subs-prefix.*\")",
+	).Strings()
 
 	monitoringMetricsAggregateDeltas = kingpin.Flag(
 		"monitoring.aggregate-deltas", "If enabled will treat all DELTA metrics as an in-memory counter instead of a gauge",
@@ -356,11 +358,11 @@ func main() {
 func parseMetricExtraFilters() []collectors.MetricFilter {
 	var extraFilters []collectors.MetricFilter
 	for _, ef := range *monitoringMetricsExtraFilter {
-		efPrefix, efModifier := utils.GetExtraFilterModifiers(ef, ":")
-		if efPrefix != "" {
+		targetedMetricPrefix, filterQuery := utils.SplitExtraFilter(ef, ":")
+		if targetedMetricPrefix != "" {
 			extraFilter := collectors.MetricFilter{
-				Prefix:   efPrefix,
-				Modifier: efModifier,
+				TargetedMetricPrefix: targetedMetricPrefix,
+				FilterQuery:          filterQuery,
 			}
 			extraFilters = append(extraFilters, extraFilter)
 		}

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -279,16 +279,6 @@ func main() {
 		}
 	}
 
-	level.Info(logger).Log(
-		"msg", "Starting stackdriver_exporter",
-		"version", version.Info(),
-		"build_context", version.BuildContext(),
-		"projects", *projectID,
-		"metric_prefixes", *monitoringMetricsTypePrefixes,
-		"extra_filters", strings.Join(*monitoringMetricsExtraFilter, ","),
-	)
-	level.Info(logger).Log("msg", "Build context", "build_context", version.BuildContext())
-
 	monitoringService, err := createMonitoringService(ctx)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to create monitoring service", "err", err)
@@ -298,7 +288,6 @@ func main() {
 	var projectIDs []string
 
 	if *projectsFilter != "" {
-		level.Info(logger).Log("msg", "Using Google Cloud Projects Filter", "projectsFilter", *projectsFilter)
 		projectIDs, err = utils.GetProjectIDsFromFilter(ctx, *projectsFilter)
 		if err != nil {
 			level.Error(logger).Log("msg", "failed to get project IDs from filter", "err", err)
@@ -310,7 +299,16 @@ func main() {
 		projectIDs = append(projectIDs, strings.Split(*projectID, ",")...)
 	}
 
-	level.Info(logger).Log("msg", "Using Google Cloud Project IDs", "projectIDs", fmt.Sprintf("%v", projectIDs))
+	level.Info(logger).Log(
+		"msg", "Starting stackdriver_exporter",
+		"version", version.Info(),
+		"build_context", version.BuildContext(),
+		"projects", *projectID,
+		"metric_prefixes", *monitoringMetricsTypePrefixes,
+		"extra_filters", strings.Join(*monitoringMetricsExtraFilter, ","),
+		"projectIDs", fmt.Sprintf("%v", projectIDs),
+		"projectsFilter", *projectsFilter,
+	)
 
 	metricsTypePrefixes := strings.Split(*monitoringMetricsTypePrefixes, ",")
 	metricExtraFilters := parseMetricExtraFilters()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -41,7 +41,7 @@ func NormalizeMetricName(metricName string) string {
 	return strings.Join(normalizedMetricName, "_")
 }
 
-func GetExtraFilterModifiers(extraFilter string, separator string) (string, string) {
+func SplitExtraFilter(extraFilter string, separator string) (string, string) {
 	mPrefix := strings.Split(extraFilter, separator)
 	if mPrefix[0] == extraFilter {
 		return "", ""


### PR DESCRIPTION
Adjusts the way `monitoring.filters` are documented and applied. 

Similar to #165, I found it hard to use the filters initially so hopefully more detailed docs can help. Especially related to the fact that the `monitoring.filters` flag should be specified multiple times vs comma delimited like other multi-valued params.

This also adjusts the way the filters are applied to be based on prefix vs contains, https://github.com/prometheus-community/stackdriver_exporter/pull/198/commits/507f6b3119310e14e3a62e66b30100f899e00de0. I think the original contains implementation made it hard to define what exactly belongs in the first section of the extra_filters. Forcing it to be a prefix makes it a lot more concrete.