### PR TITLE
cache descriptors to reduce API calls

### DIFF
--- a/collectors/cache.go
+++ b/collectors/cache.go
@@ -1,0 +1,74 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import (
+	"sync"
+	"time"
+
+	"google.golang.org/api/monitoring/v3"
+)
+
+type DescriptorCache interface {
+	// Lookup searches the cache for an entry. If the cache has no entry or the entry has expired nil is returned.
+	Lookup(prefix string) []*monitoring.MetricDescriptor
+
+	// Store stores an entry in the cache
+	Store(prefix string, data []*monitoring.MetricDescriptor)
+}
+
+type noopDescriptorCache struct{}
+
+func (d *noopDescriptorCache) Lookup(prefix string) []*monitoring.MetricDescriptor {
+	return nil
+}
+
+func (d *noopDescriptorCache) Store(prefix string, data []*monitoring.MetricDescriptor) {}
+
+// descriptorCache is a MetricTypePrefix -> MetricDescriptor cache
+type descriptorCache struct {
+	cache map[string]*descriptorCacheEntry
+	lock  sync.Mutex
+	ttl   time.Duration
+}
+
+type descriptorCacheEntry struct {
+	data   []*monitoring.MetricDescriptor
+	expiry time.Time
+}
+
+func newDescriptorCache(ttl time.Duration) *descriptorCache {
+	return &descriptorCache{ttl: ttl, cache: make(map[string]*descriptorCacheEntry)}
+}
+
+// Lookup returns a list of MetricDescriptors if the prefix is found, nil if not found or expired
+func (d *descriptorCache) Lookup(prefix string) []*monitoring.MetricDescriptor {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	v, ok := d.cache[prefix]
+	if !ok || time.Now().After(v.expiry) {
+		return nil
+	}
+
+	return v.data
+}
+
+// Store overrides a cache entry
+func (d *descriptorCache) Store(prefix string, data []*monitoring.MetricDescriptor) {
+	entry := descriptorCacheEntry{data: data, expiry: time.Now().Add(d.ttl)}
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.cache[prefix] = &entry
+}

--- a/collectors/cache_test.go
+++ b/collectors/cache_test.go
@@ -1,0 +1,76 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"google.golang.org/api/monitoring/v3"
+)
+
+func makeDummyMetrics(n int) []*monitoring.MetricDescriptor {
+	ret := make([]*monitoring.MetricDescriptor, n)
+	for i := 0; i < n; i++ {
+		ret[i] = &monitoring.MetricDescriptor{
+			DisplayName: fmt.Sprintf("test-%d", i),
+		}
+	}
+	return ret
+}
+
+func isEqual(a, b []*monitoring.MetricDescriptor) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for idx, e := range a {
+		if e.DisplayName != b[idx].DisplayName {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestDescriptorCache(t *testing.T) {
+	ttl := 1 * time.Second
+	cache := newDescriptorCache(ttl)
+	entries := makeDummyMetrics(10)
+	key := "akey"
+
+	if cache.Lookup(key) != nil {
+		t.Errorf("Cache should've returned nil on lookup without store")
+	}
+
+	cache.Store("more", makeDummyMetrics(10))
+	cache.Store("evenmore", makeDummyMetrics(10))
+
+	cache.Store(key, entries)
+	newEntries := cache.Lookup(key)
+
+	if newEntries == nil {
+		t.Errorf("Cache returned unexpected nil")
+	}
+
+	if !isEqual(entries, newEntries) {
+		t.Errorf("Cache modified entries")
+	}
+
+	time.Sleep(ttl)
+	if cache.Lookup(key) != nil {
+		t.Error("cache entries should have expired")
+	}
+}

--- a/collectors/monitoring_collector_test.go
+++ b/collectors/monitoring_collector_test.go
@@ -1,0 +1,39 @@
+// Copyright 2023 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectors
+
+import "testing"
+
+func TestIsGoogleMetric(t *testing.T) {
+	good := []string{
+		"pubsub.googleapis.com/some/metric",
+	}
+
+	bad := []string{
+		"my.metric/a/b",
+		"my.metrics/pubsub.googleapis.com/a",
+	}
+
+	for _, e := range good {
+		if !isGoogleMetric(e) {
+			t.Errorf("should be a google metric: %s", e)
+		}
+	}
+
+	for _, e := range bad {
+		if isGoogleMetric(e) {
+			t.Errorf("should not be a google metric: %s", e)
+		}
+	}
+}


### PR DESCRIPTION
See issue #217

This commit introduces a simple prefix -> []descriptor cache. If the prefix isn't in the cache the original page based lookup is performed and at the end of it the cache is updated. If it does exist in the cache the cached value is used.
No attempt is made to prevent two routines from updating the cache concurrently. If two concurrent requests see an expired cache entry they'll both do the ListDescriptor call and update the cache. Doing this keeps the cache simple and doesn't block one request on the other. This situation will also be rare in practice, as there is usually only one or two prometheuses scraping.

The cache itself comes in 3 flavors:

- noop, does nothing
- descriptorCache, caches all descriptors
- googleDescriptorCache, caches only descriptors of google metrics

The cache is disabled by default and can be enabled with the new `--monitoring.descriptor-cache-ttl` CLI flag, if the TTL is set to a value >0s the cache is enabled. It defaults to using the google only cache, to control that the
`--no-monitoring.descriptor-cache-only-google` is introduced