### PR TITLE
Restore port to 9255

### DIFF
--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -43,7 +43,7 @@ import (
 var (
 	// General exporter flags
 
-	toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9225")
+	toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9255")
 
 	metricsPath = kingpin.Flag(
 		"web.telemetry-path", "Path under which to expose Prometheus metrics.",


### PR DESCRIPTION
6cb7206e17ed accidentally changed the port to 9225

diff:

```
-       ).Default(":9255").String()
+       toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9225")
```

@taisph noticed it in https://github.com/prometheus-community/stackdriver_exporter/pull/226#discussion_r1206715493

@SuperQ 
