### PR TITLE
fix(docs): Update CONTRIBUTING.md to reflect build process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ For complete instructions on how to compile see: [Building From Source](https://
 For quickly compiling and testing your changes do:
 ```
 # For building.
-go build ./cmd/prometheus/
-./prometheus
+go build .
+./stackdriver_exporter
 
 # For testing.
 make test         # Make sure all the tests pass before you commit and push :)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ For complete instructions on how to compile see: [Building From Source](https://
 For quickly compiling and testing your changes do:
 ```
 # For building.
-go build .
+make build
 ./stackdriver_exporter
 
 # For testing.


### PR DESCRIPTION
Updates the CONTRIBUTING.md file to have the proper command to build and run `stackdriver_exporter`.