### PR TITLE
Sanitize metric type prefixes

### DIFF
--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -356,19 +356,12 @@ func main() {
 }
 
 func parseMetricTypePrefixes(inputPrefixes []string) (metricTypePrefixes []string) {
-	// only keep unique prefixes
-	uniqueKeys := make(map[string]bool)
-	uniquePrefixes := []string{}
-	for _, prefix := range inputPrefixes {
-		if _, ok := uniqueKeys[prefix]; !ok {
-			uniqueKeys[prefix] = true
-			uniquePrefixes = append(uniquePrefixes, prefix)
-		}
-	}
+	// drop duplicate prefixes
+	slices.Sort(inputPrefixes)
+	uniquePrefixes := slices.Compact(inputPrefixes)
 
 	// drop prefixes that start with another existing prefix to avoid error:
 	// "collected metric xxx was collected before with the same name and label values"
-	slices.Sort(uniquePrefixes)
 	for i, prefix := range uniquePrefixes {
 		if i == 0 {
 			metricTypePrefixes = []string{prefix}

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -304,7 +304,8 @@ func main() {
 
 	level.Info(logger).Log("msg", "Using Google Cloud Project IDs", "projectIDs", fmt.Sprintf("%v", projectIDs))
 
-	metricsTypePrefixes := parseMetricTypePrefixes()
+	inputPrefixes := strings.Split(*monitoringMetricsTypePrefixes, ",")
+	metricsTypePrefixes := parseMetricTypePrefixes(inputPrefixes)
 	metricExtraFilters := parseMetricExtraFilters()
 
 	if *metricsPath == *stackdriverMetricsPath {
@@ -354,9 +355,7 @@ func main() {
 	}
 }
 
-func parseMetricTypePrefixes() (metricTypePrefixes []string) {
-	inputPrefixes := strings.Split(*monitoringMetricsTypePrefixes, ",")
-
+func parseMetricTypePrefixes(inputPrefixes []string) (metricTypePrefixes []string) {
 	// only keep unique prefixes
 	uniqueKeys := make(map[string]bool)
 	uniquePrefixes := []string{}

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -382,12 +382,6 @@ func parseMetricTypePrefixes() (metricTypePrefixes []string) {
 				continue
 			}
 
-			// previous prefix starts with current prefix
-			if strings.HasPrefix(metricTypePrefixes[previousIndex], prefix) {
-				// drop previous prefix
-				metricTypePrefixes = metricTypePrefixes[:previousIndex]
-			}
-
 			metricTypePrefixes = append(metricTypePrefixes, prefix)
 		}
 	}

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -355,7 +355,9 @@ func main() {
 	}
 }
 
-func parseMetricTypePrefixes(inputPrefixes []string) (metricTypePrefixes []string) {
+func parseMetricTypePrefixes(inputPrefixes []string) []string {
+	metricTypePrefixes := []string{}
+
 	// Drop duplicate prefixes.
 	slices.Sort(inputPrefixes)
 	uniquePrefixes := slices.Compact(inputPrefixes)
@@ -364,7 +366,7 @@ func parseMetricTypePrefixes(inputPrefixes []string) (metricTypePrefixes []strin
 	// "collected metric xxx was collected before with the same name and label values".
 	for i, prefix := range uniquePrefixes {
 		if i == 0 {
-			metricTypePrefixes = []string{prefix}
+			metricTypePrefixes = append(metricTypePrefixes, prefix)
 		} else {
 			previousIndex := len(metricTypePrefixes) - 1
 

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -365,18 +365,15 @@ func parseMetricTypePrefixes(inputPrefixes []string) []string {
 	// Drop prefixes that start with another existing prefix to avoid error:
 	// "collected metric xxx was collected before with the same name and label values".
 	for i, prefix := range uniquePrefixes {
-		if i == 0 {
-			metricTypePrefixes = append(metricTypePrefixes, prefix)
-		} else {
+		if i != 0 {
 			previousIndex := len(metricTypePrefixes) - 1
 
 			// Drop current prefix if it starts with the previous one.
 			if strings.HasPrefix(prefix, metricTypePrefixes[previousIndex]) {
 				continue
 			}
-
-			metricTypePrefixes = append(metricTypePrefixes, prefix)
 		}
+		metricTypePrefixes = append(metricTypePrefixes, prefix)
 	}
 
 	return metricTypePrefixes

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -356,21 +356,20 @@ func main() {
 }
 
 func parseMetricTypePrefixes(inputPrefixes []string) (metricTypePrefixes []string) {
-	// drop duplicate prefixes
+	// Drop duplicate prefixes.
 	slices.Sort(inputPrefixes)
 	uniquePrefixes := slices.Compact(inputPrefixes)
 
-	// drop prefixes that start with another existing prefix to avoid error:
-	// "collected metric xxx was collected before with the same name and label values"
+	// Drop prefixes that start with another existing prefix to avoid error:
+	// "collected metric xxx was collected before with the same name and label values".
 	for i, prefix := range uniquePrefixes {
 		if i == 0 {
 			metricTypePrefixes = []string{prefix}
 		} else {
 			previousIndex := len(metricTypePrefixes) - 1
 
-			// current prefix starts with previous one
+			// Drop current prefix if it starts with the previous one.
 			if strings.HasPrefix(prefix, metricTypePrefixes[previousIndex]) {
-				// drop current prefix
 				continue
 			}
 

--- a/stackdriver_exporter_test.go
+++ b/stackdriver_exporter_test.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+import "reflect"
+
+func TestParseMetricTypePrefixes(t *testing.T) {
+	inputPrefixes := []string{
+		"redis.googleapis.com/stats/memory/usage",
+		"loadbalancing.googleapis.com/https/request_count",
+		"loadbalancing.googleapis.com",
+		"redis.googleapis.com/stats/memory/usage_ratio",
+		"redis.googleapis.com/stats/memory/usage_ratio",
+	}
+	expectedOutputPrefixes := []string{
+		"loadbalancing.googleapis.com",
+		"redis.googleapis.com/stats/memory/usage",
+	}
+
+	outputPrefixes := parseMetricTypePrefixes(inputPrefixes)
+
+	if !reflect.DeepEqual(outputPrefixes, expectedOutputPrefixes) {
+		t.Errorf("Metric type prefix sanitization did not produce expected output. Expected:\n%s\nGot:\n%s", expectedOutputPrefixes, outputPrefixes)
+	}
+}


### PR DESCRIPTION
When more than one prefix matches the same metric descriptor, this will throw the error `collected metric xxx was collected before with the same name and label values`.

For example, using the metric type prefixes
  `foo.googleapis.com/bar (a prefix)`
and
  `foo.googleapis.com/bar/baz (a metric)`
will result in an error because both match the metric
  `foo.googleapis.com/bar/baz`.

Further, using the metric type prefixes
  `foo.googleapis.com/bar/baz (a metric)`
and
  `foo.googleapis.com/bar/baz_count (a metric)`
will result in an error because both match the metric
  `foo.googleapis.com/bar/baz_count`.

While the first pitfall could be expected by the user, the latter will come as a complete surprise to anyone who is not aware that stackdriver-exporter internally uses an MQL query in the form of
  `metric.type = starts_with("<prefix>")`
to filter the metrics.

Avoid this by sanitizing the provided metric type prefixes in the following way:
- Drop any duplicate prefixes
- Sort the prefixes (required by the next step)
- Drop any prefixes that start with another prefix present in the input

Fixes https://github.com/prometheus-community/stackdriver_exporter/issues/103