### PR TITLE
[Bugfix]: Fix histogram merge 

### DIFF
--- a/collectors/monitoring_metrics.go
+++ b/collectors/monitoring_metrics.go
@@ -102,13 +102,13 @@ type HistogramMetric struct {
 
 func (t *timeSeriesMetrics) CollectNewConstHistogram(timeSeries *monitoring.TimeSeries, reportTime time.Time, labelKeys []string, dist *monitoring.Distribution, buckets map[float64]uint64, labelValues []string, metricKind string) {
 	fqName := buildFQName(timeSeries)
-
+	histogramSum := dist.Mean * float64(dist.Count)
 	var v HistogramMetric
 	if t.fillMissingLabels || (metricKind == "DELTA" && t.aggregateDeltas) {
 		v = HistogramMetric{
 			FqName:         fqName,
 			LabelKeys:      labelKeys,
-			Sum:            dist.Mean * float64(dist.Count),
+			Sum:            histogramSum,
 			Count:          uint64(dist.Count),
 			Buckets:        buckets,
 			LabelValues:    labelValues,
@@ -133,7 +133,7 @@ func (t *timeSeriesMetrics) CollectNewConstHistogram(timeSeries *monitoring.Time
 		return
 	}
 
-	t.ch <- t.newConstHistogram(fqName, reportTime, labelKeys, dist.Mean, uint64(dist.Count), buckets, labelValues)
+	t.ch <- t.newConstHistogram(fqName, reportTime, labelKeys, histogramSum, uint64(dist.Count), buckets, labelValues)
 }
 
 func (t *timeSeriesMetrics) newConstHistogram(fqName string, reportTime time.Time, labelKeys []string, sum float64, count uint64, buckets map[float64]uint64, labelValues []string) prometheus.Metric {

--- a/collectors/monitoring_metrics.go
+++ b/collectors/monitoring_metrics.go
@@ -100,6 +100,17 @@ type HistogramMetric struct {
 	KeysHash uint64
 }
 
+func (h *HistogramMetric) MergeHistogram(other *HistogramMetric) {
+	// Increment totals based on incoming totals
+	h.Sum += other.Sum
+	h.Count += other.Count
+
+	// Merge the buckets from existing in to current
+	for key, value := range other.Buckets {
+		h.Buckets[key] += value
+	}
+}
+
 func (t *timeSeriesMetrics) CollectNewConstHistogram(timeSeries *monitoring.TimeSeries, reportTime time.Time, labelKeys []string, dist *monitoring.Distribution, buckets map[float64]uint64, labelValues []string, metricKind string) {
 	fqName := buildFQName(timeSeries)
 	histogramSum := dist.Mean * float64(dist.Count)

--- a/delta/histogram_test.go
+++ b/delta/histogram_test.go
@@ -29,15 +29,17 @@ var _ = Describe("HistogramStore", func() {
 	var store *delta.InMemoryHistogramStore
 	var histogram *collectors.HistogramMetric
 	descriptor := &monitoring.MetricDescriptor{Name: "This is a metric"}
+	bucketKey := 1.00000000000000000001
+	bucketValue := uint64(1000)
 
 	BeforeEach(func() {
 		store = delta.NewInMemoryHistogramStore(promlog.New(&promlog.Config{}), time.Minute)
 		histogram = &collectors.HistogramMetric{
 			FqName:         "histogram_name",
 			LabelKeys:      []string{"labelKey"},
-			Mean:           10,
+			Sum:            10,
 			Count:          100,
-			Buckets:        map[float64]uint64{1.00000000000000000001: 1000},
+			Buckets:        map[float64]uint64{bucketKey: bucketValue},
 			LabelValues:    []string{"labelValue"},
 			ReportTime:     time.Now().Truncate(time.Second),
 			CollectionTime: time.Now().Truncate(time.Second),
@@ -51,6 +53,34 @@ var _ = Describe("HistogramStore", func() {
 
 		Expect(len(metrics)).To(Equal(1))
 		Expect(metrics[0]).To(Equal(histogram))
+	})
+
+	It("can merge histograms", func() {
+		store.Increment(descriptor, histogram)
+
+		// Shallow copy and change report time so they will merge
+		nextValue := &collectors.HistogramMetric{
+			FqName:         "histogram_name",
+			LabelKeys:      []string{"labelKey"},
+			Sum:            10,
+			Count:          100,
+			Buckets:        map[float64]uint64{bucketKey: bucketValue},
+			LabelValues:    []string{"labelValue"},
+			ReportTime:     time.Now().Truncate(time.Second).Add(time.Second),
+			CollectionTime: time.Now().Truncate(time.Second),
+			KeysHash:       8765,
+		}
+
+		store.Increment(descriptor, nextValue)
+
+		metrics := store.ListMetrics(descriptor.Name)
+
+		Expect(len(metrics)).To(Equal(1))
+		histogram := metrics[0]
+		Expect(histogram.Count).To(Equal(uint64(200)))
+		Expect(histogram.Sum).To(Equal(20.0))
+		Expect(len(histogram.Buckets)).To(Equal(1))
+		Expect(histogram.Buckets[bucketKey]).To(Equal(bucketValue * 2))
 	})
 
 	It("will remove histograms outside of TTL", func() {


### PR DESCRIPTION
The current implementation is not merging the histogram correctly. The sum is calculated as follow:

count * (existingMean + currentMean) / 2

Now let's say that the existing histogram has a count of 1000 and an existing mean of 10000, the incoming histogram has a count of 100 and a mean of 1000.

newCount = 1000 + 100 = 1100
newMean = (10000 + 1000) / 2 = 5500
newSum = 1100 * newMean = 6_050_000

Now the next incoming histogram has a count of 1000 and an existing mean of 100:

newCount = 1100 + 1000 = 2100
newMean = (5500 +100) / 2 = 2800
newSum = 2100 * 2800 = 5_880_000

By definition, the sum of the histogram is supposed to behave like a counter (A counter is a cumulative metric that represents a single [monotonically increasing counter](https://en.wikipedia.org/wiki/Monotonic_function) whose value can only increase or be reset to zero on restart.)

In the example above, the sum decreased (5_880_000 < 6_050_000) which is not something that should happen.

You can see it happening with real values:

![image](https://github.com/prometheus-community/stackdriver_exporter/assets/21154204/f021b826-2c27-45df-88aa-1182a92928d2)

With this PR, the computation of the sum changes to the following:

sum = existingSum + (currentMean * count)

Taking the previous example, we would have:

previousSum = 10_000_000
newSum = previousSum * (1000 * 100) = 10_100_000

previousSum = 10_100_000
newSum = previousSum * (100 * 1000) = 10_200_000

The sum is increasing and the computation is correct: (the sum of 100 buckets with a mean value of 1000 should be equal to the sum of 1000 buckets with a mean value of 100)



