### PR TITLE
Add project IDs to error logs

### DIFF
--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -123,6 +123,8 @@ type DeltaHistogramStore interface {
 func NewMonitoringCollector(projectID string, monitoringService *monitoring.Service, opts MonitoringCollectorOptions, logger log.Logger, counterStore DeltaCounterStore, histogramStore DeltaHistogramStore) (*MonitoringCollector, error) {
 	const subsystem = "monitoring"
 
+	logger = log.With(logger, "project_id", projectID)
+
 	apiCallsTotalMetric := prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace:   namespace,


### PR DESCRIPTION
When exporting metrics from multiple projects at once, it's useful to know which of the projects is generating metrics errors.

Heya @SuperQ , tagging you per the contributors guide. Mind taking a look when you get a minute?