### PR TITLE
feat: support more specific prefixes in ?collect parameter

### DIFF
--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -257,12 +257,14 @@ func (h *handler) filterMetricTypePrefixes(filters map[string]bool) []string {
 	if len(filters) > 0 {
 		filteredPrefixes = nil
 		for _, prefix := range h.metricsPrefixes {
-			if filters[prefix] {
-				filteredPrefixes = append(filteredPrefixes, prefix)
+			for filter, _ := range filters {
+				if strings.HasPrefix(filter, prefix) {
+					filteredPrefixes = append(filteredPrefixes, filter)
+				}
 			}
 		}
 	}
-	return filteredPrefixes
+	return parseMetricTypePrefixes(filteredPrefixes)
 }
 
 func main() {

--- a/stackdriver_exporter_test.go
+++ b/stackdriver_exporter_test.go
@@ -35,3 +35,29 @@ func TestParseMetricTypePrefixes(t *testing.T) {
 		t.Errorf("Metric type prefix sanitization did not produce expected output. Expected:\n%s\nGot:\n%s", expectedOutputPrefixes, outputPrefixes)
 	}
 }
+
+func TestFilterMetricTypePrefixes(t *testing.T) {
+	metricPrefixes := []string{
+		"redis.googleapis.com/stats/",
+	}
+
+	h := &handler{
+		metricsPrefixes: metricPrefixes,
+	}
+
+	inputFilters := map[string]bool{
+		"redis.googleapis.com/stats/memory/usage":       true,
+		"redis.googleapis.com/stats/memory/usage_ratio": true,
+		"redis.googleapis.com":                          true,
+	}
+
+	expectedOutputPrefixes := []string{
+		"redis.googleapis.com/stats/memory/usage",
+	}
+
+	outputPrefixes := h.filterMetricTypePrefixes(inputFilters)
+
+	if !reflect.DeepEqual(outputPrefixes, expectedOutputPrefixes) {
+		t.Errorf("filterMetricTypePrefixes did not produce expected output. Expected:\n%s\nGot:\n%s", expectedOutputPrefixes, outputPrefixes)
+	}
+}


### PR DESCRIPTION
This changes the `?collect` parameter filter to allow more specific prefixes than those setup in the metrics-prefixes.

Example use cases:

1. I have the `redis.googleapis.com/stats/memory/usage_ratio` prefix set in the `?collect` config of dozens of projects. 

Now, I'd like to enable the `redis.googleapis.com/stats/memory/usage` metric in the stackdriver_exporter metric prefixes, but since it conflicts with the more-specific `redis.googleapis.com/stats/memory/usage_ratio` metric name, the exporter will stop accepting the `?collect` param I've set in other configurations.

2. I want to whitelist all `redis.googleapis.com` metrics, but only collect 1 or 2 metrics with `?collect`. Currently, the prefixes have to be exact matches so this is not possible without the proposed change.

---

To test:
```
$ go run . --google.project-id=<gcp-project-name> --monitoring.metrics-prefixes=redis.googleapis.com/stats/
$ curl http://localhost:9255/metrics?collect=redis.googleapis.com/stats/memory/usage/ | grep stackdriver_redis
```

---

Other question: is there a technical reason that would prevent from having a flag disabling prefix filtering in `?collect`?

