### PR TITLE
Fixup linter warning

### DIFF
--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -289,7 +289,7 @@ func (h *handler) filterMetricTypePrefixes(filters map[string]bool) []string {
 	if len(filters) > 0 {
 		filteredPrefixes = nil
 		for _, prefix := range h.metricsPrefixes {
-			for filter, _ := range filters {
+			for filter := range filters {
 				if strings.HasPrefix(filter, prefix) {
 					filteredPrefixes = append(filteredPrefixes, filter)
 				}


### PR DESCRIPTION
Fixup warning:
> S1005: unnecessary assignment to the blank identifier (gosimple)