### PR TITLE
superq/ghcr io org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,12 @@ jobs:
       # should also be updated.
       image: quay.io/prometheus/golang-builder:1.26-base
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
       - run: make GO_ONLY=1 SKIP_GOLANGCI_LINT=1
+      - run: git diff --exit-code
 
   build:
     name: Build
@@ -36,8 +37,8 @@ jobs:
           parallelism: 4
           thread: ${{ matrix.thread }}
 
-  publish_main:
-    name: Publish main branch artifacts
+  publish_default:
+    name: Publish default branch artifacts
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
- **Metrics-ingest-delay bugfix (#151)**
- **Update common Prometheus files (#156)**
- **request time object data race fixed (#158)**
- **Make Stackdriver main collector more library-friendly (#157)**
- **Add trailing backtick for monitoring.metrics-type-prefixes (#159)**
- **Update common Prometheus files (#161)**
- **Update common Prometheus files (#163)**
- **Fix README call with --google.project-id (#160)**
- **Make it possible to support runtime metrics on a seperate path (#173)**
- **Update common Prometheus files (#176)**
- **Track delta metrics between scrapes (#168)**
- **Refactor metric naming (#174)**
- **Update build (#177)**
- **Bump google.golang.org/api from 0.75.0 to 0.103.0**
- **Bump github.com/onsi/gomega from 1.19.0 to 1.24.1**
- **Add status badges to README (#170)**
- **Update common Prometheus files**
- **Bump github.com/prometheus/common from 0.37.0 to 0.39.0**
- **Bump golang.org/x/oauth2 from 0.3.0 to 0.4.0**
- **Bump google.golang.org/api from 0.103.0 to 0.108.0**
- **Bump github.com/onsi/gomega from 1.24.1 to 1.26.0**
- **Release 0.13.0**
- **Update common Prometheus files**
- **Mention community Helm chart in README**
- **Update common Prometheus files**
- **Update build**
- **Bump github.com/alecthomas/kingpin/v2 from 2.3.1 to 2.3.2**
- **Bump golang.org/x/net from 0.5.0 to 0.8.0**
- **Bump golang.org/x/oauth2 from 0.4.0 to 0.6.0**
- **Bump github.com/onsi/gomega from 1.26.0 to 1.27.6**
- **Bump google.golang.org/api from 0.108.0 to 0.114.0**
- **Update golangci-lint settings**
- **Bump golang.org/x/oauth2 from 0.6.0 to 0.7.0**
- **Bump github.com/prometheus/client_golang from 1.14.0 to 1.15.1**
- **Bump google.golang.org/api from 0.114.0 to 0.121.0**
- **cache descriptors to reduce API calls (#218)**
- **Release v0.14.0 (#226)**
- **Fix default listening port (#229)**
- **Update PR number in changelog.**
- **Bump google.golang.org/api from 0.124.0 to 0.125.0 (#231)**
- **Bump github.com/onsi/gomega from 1.27.6 to 1.27.7 (#230)**
- **Update common Prometheus files (#234)**
- **Bump github.com/prometheus/client_golang from 1.15.1 to 1.16.0 (#237)**
- **Bump google.golang.org/api from 0.125.0 to 0.134.0 (#251)**
- **Bump github.com/onsi/gomega from 1.27.7 to 1.27.10 (#249)**
- **Update common Prometheus files (#235)**
- **Readme missing backtick (#257)**
- **Bump google.golang.org/api from 0.134.0 to 0.143.0 (#267)**
- **Bump github.com/onsi/gomega from 1.27.10 to 1.28.0 (#266)**
- **Bump github.com/PuerkitoBio/rehttp from 1.1.0 to 1.2.0 (#259)**
- **feat: add projects query (#243)**
- **Bump golang.org/x/net from 0.15.0 to 0.17.0 (#268)**
- **Update common Prometheus files (#253)**
- **Bump google.golang.org/grpc from 1.57.0 to 1.57.1 (#269)**
- **Correct backticks in readme table round 2 (#258)**
- **Update common Prometheus files (#270)**
- **Refactor delta logic for library usage (#190)**
- **Bump google.golang.org/api from 0.143.0 to 0.152.0 (#281)**
- **Bump github.com/PuerkitoBio/rehttp from 1.2.0 to 1.3.0 (#274)**
- **Bump golang.org/x/crypto from 0.14.0 to 0.17.0 (#283)**
- **Bump golang.org/x/oauth2 from 0.12.0 to 0.15.0 (#282)**
- **Update common Prometheus files (#278)**
- **Update common Prometheus files (#284)**
- **Bump github.com/onsi/gomega from 1.28.0 to 1.30.0 (#288)**
- **Bump github.com/alecthomas/kingpin/v2 from 2.3.2 to 2.4.0 (#287)**
- **Update build (#291)**
- **Update common Prometheus files (#294)**
- **Bump google.golang.org/api from 0.152.0 to 0.167.0 (#305)**
- **Bump github.com/prometheus/client_golang from 1.18.0 to 1.19.0 (#308)**
- **Update common Prometheus files (#310)**
- **Bump github.com/PuerkitoBio/rehttp from 1.3.0 to 1.4.0 (#309)**
- **Update common Prometheus files (#311)**
- **Bump github.com/onsi/gomega from 1.30.0 to 1.31.1 (#297)**
- **Update common Prometheus files (#313)**
- **Update Go (#312)**
- **fix(docs): Update CONTRIBUTING.md to reflect build process (#276)**
- **Release v0.15.0 (#314)**
- **Add feature to filter project ID at call-time (#164)**
- **Revert "Add feature to filter project ID at call-time (#164)" (#316)**
- **[Bugfix]: Fix histogram merge  (#324)**
- **Bump github.com/prometheus/common from 0.50.0 to 0.53.0 (#329)**
- **Bump golang.org/x/net from 0.22.0 to 0.24.0 (#328)**
- **Bump github.com/onsi/gomega from 1.31.1 to 1.33.1 (#326)**
- **Update common Prometheus files (#317)**
- **Bump golang.org/x/oauth2 from 0.18.0 to 0.20.0 (#333)**
- **Bump github.com/prometheus/client_golang from 1.19.0 to 1.19.1 (#332)**
- **Update common Prometheus files (#334)**
- **Bump google.golang.org/api from 0.168.0 to 0.180.0 (#330)**
- **Release v0.15.1 (#335)**
- **Update common Prometheus files (#337)**
- **Bump google.golang.org/api from 0.180.0 to 0.182.0 (#338)**
- **Update common Prometheus files (#340)**
- **Add more info about filters to docs and rename struct fields (#198)**
- **Bump github.com/prometheus/common from 0.53.0 to 0.55.0 (#345)**
- **Update common Prometheus files (#341)**
- **Bump google.golang.org/api from 0.182.0 to 0.186.0 (#343)**
- **feat(stackdriver_exporter): Add ErrorLogger for promhttp (#277)**
- **Update common Prometheus files (#346)**
- **Bump google.golang.org/grpc from 1.64.0 to 1.64.1 (#347)**
- **Update common Prometheus files (#349)**
- **Bump google.golang.org/api from 0.186.0 to 0.188.0 (#350)**
- **Bump golang.org/x/net from 0.26.0 to 0.27.0 (#351)**
- **Release 0.16.0 (#348)**
- **Add new maintainer (#352)**
- **Sanitize metric type prefixes (#319)**
- **Update example in README.md (#358)**
- **Update common Prometheus files (#357)**
- **Bump github.com/onsi/gomega from 1.33.1 to 1.34.1 (#353)**
- **Bump google.golang.org/api from 0.188.0 to 0.189.0 (#354)**
- **Update common Prometheus files (#363)**
- **Bump github.com/prometheus/client_golang from 1.19.1 to 1.20.2 (#368)**
- **Bump google.golang.org/api from 0.189.0 to 0.195.0 (#365)**
- **Add project ID to all logs from the collector (#362)**
- **Bump github.com/prometheus/common from 0.55.0 to 0.58.0 (#369)**
- **Update common Prometheus files**
- **Bump github.com/prometheus/common from 0.58.0 to 0.59.1 (#372)**
- **Bump golang.org/x/net from 0.28.0 to 0.29.0 (#373)**
- **Bump google.golang.org/api from 0.195.0 to 0.199.0 (#375)**
- **Replace comma-delimited string flags with repeatable flags (#355)**
- **chore!: adopt log/slog, drop go-kit/log (#378)**
- **Update common Prometheus files (#377)**
- **Bump github.com/prometheus/common from 0.59.1 to 0.60.1 (#379)**
- **Bump google.golang.org/api from 0.199.0 to 0.204.0 (#380)**
- **Update Go build (#384)**
- **Bump github.com/onsi/gomega from 1.34.1 to 1.35.1 (#383)**
- **Bump github.com/prometheus/exporter-toolkit from 0.11.0 to 0.13.1 (#381)**
- **Release 0.17.0 (#376)**
- **Update common Prometheus files (#385)**
- **Update common Prometheus files (#388)**
- **feat: support more specific prefixes in ?collect parameter (#387)**
- **Fix monitoring metrics for individual collectors (#389)**
- **Update common Prometheus files (#391)**
- **Bump github.com/prometheus/exporter-toolkit from 0.13.1 to 0.13.2 (#398)**
- **Bump golang.org/x/net from 0.32.0 to 0.34.0 (#402)**
- **Bump google.golang.org/api from 0.204.0 to 0.217.0 (#403)**
- **Bump github.com/onsi/gomega from 1.35.1 to 1.36.2 (#399)**
- **Fixup linter warning (#406)**
- **Release 0.18.0 (#404)**
- **Update common Prometheus files (#407)**
- **Update common Prometheus files (#410)**
- **Cleanup golangci-lint config (#418)**
- **Update Go (#419)**
- **Bump google.golang.org/api from 0.217.0 to 0.224.0 (#420)**
- **Update common Prometheus files (#421)**
- **Update common Prometheus files (#422)**
- **Fix metrics filter with colon `:` in query value (#428)**
- **feat: Add google.universe-domain flag for custom GoogleCloud universes (#430)**
- **Bump github.com/prometheus/exporter-toolkit from 0.13.2 to 0.14.1 (#458)**
- **Update common Prometheus files (#423)**
- **Update build (#460)**
- **Bump google.golang.org/api from 0.224.0 to 0.251.0 (#457)**
- **Bump github.com/onsi/gomega from 1.36.2 to 1.38.2 (#451)**
- **Synchronize common files from prometheus/prometheus (#461)**
- **Update common Prometheus files (#462)**
- **Update common Prometheus files (#471)**
- **Update common Prometheus files (#473)**
- **Bump github.com/prometheus/client_golang from 1.21.1 to 1.23.2 (#465)**
- **Implement prometheus-collector-bridge (#477)**
- **Update dependency to the official prometheus library (#481)**
- **Bump google.golang.org/grpc from 1.75.1 to 1.79.3 (#479)**
- **Update common Prometheus files (#482)**
- **Bump golang.org/x/oauth2 from 0.31.0 to 0.32.0 (#466)**
- **Update common Prometheus files (#484)**
- **Update common Prometheus files (#485)**
- **Update common Prometheus files (#488)**
- **chore: Use single source of truth for config (#483)**
- **Migrate to PromCI (#490)**
- **Update common Prometheus files (#489)**
- **Update common Prometheus files (#495)**
- **Update common Prometheus files (#496)**
- **otelcollector: Re-use logger from bridge (#497)**
- **Remove otelcollector package (#499)**
- **Synchronize common files from prometheus/prometheus (#501)**
- **collectors: consolidate config and introduce Runtime (#500)**
- **Update common Prometheus files (#503)**
- **ci: use github.token instead of PROMBOT_GITHUB_TOKEN in publish_release (#504)**
- **Bump github.com/prometheus/exporter-toolkit from 0.14.1 to 0.16.0 (#492)**
- **Bump github.com/prometheus/common from 0.67.5 to 0.68.1 (#493)**
- **Bump github.com/onsi/gomega from 1.38.2 to 1.41.0 (#491)**
- **Bump go.opentelemetry.io/otel from 1.39.0 to 1.41.0 (#498)**
- **Bump google.golang.org/api from 0.251.0 to 0.283.0 (#494)**
- **Update common Prometheus files (#506)**
- **Use upstream docker archs (#487)**
- **Release 0.19.0 (#507)**
- **Fix ghcr.io publishing org (#509)**
- **Update PromCI**
